### PR TITLE
feature/failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
 	},
 	"dependencies": {
 		"redux-saga": "^0.15.6",
-		"studiokit-net-js": "^1.2.1"
+		"studiokit-net-js": "^1.3.0"
 	},
 	"lint-staged": {
 		"*.js": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -3592,9 +3592,9 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
-studiokit-net-js@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/studiokit-net-js/-/studiokit-net-js-1.2.1.tgz#6731409b5e10368c8b3175995852d8e4e16a4987"
+studiokit-net-js@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/studiokit-net-js/-/studiokit-net-js-1.3.0.tgz#04b83b50fbc0b90fa97c4f12486d02a556ffad45"
   dependencies:
     lodash "^4.17.4"
     redux "^3.6.0"


### PR DESCRIPTION
- updated `studiokit-net-js` (WIP: https://github.com/purdue-tlt/studiokit-net-js/pull/8)
- correctly use `TRANSIENT_` action types
- update `getTokenFromRefreshToken` to check `fetchFailed.errorData` and ignore errors if they were caused by a **time out** or a **server error** (500). a failed refresh in these cases will NOT clear the token and log out the user, but will continue with the current expired token, allowing for more retries.